### PR TITLE
New platform - Ubuntu 16.04/xenial

### DIFF
--- a/ubuntu16/Dockerfile
+++ b/ubuntu16/Dockerfile
@@ -1,0 +1,37 @@
+#
+# Based on:
+#
+# * evarga/jenkins-slave:latest
+# * indigo-dc/packaging:bubuntu_latest
+#
+FROM ubuntu:16.04
+MAINTAINER František Dvořák <valtri@civ.zcu.cz>
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# UTF-8 locale
+RUN locale-gen en_US.UTF-8
+
+# ssh, sudo, java - maven default, build tools
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssh-server \
+  && apt-get install -y --no-install-recommends sudo \
+  && apt-get install -y --no-install-recommends build-essential gcc git maven cmake dpkg-dev devscripts debhelper \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -f /var/cache/apt/*.bin
+RUN sed -i 's|session    required     pam_loginuid.so|session    optional     pam_loginuid.so|g' /etc/pam.d/sshd \
+  && mkdir /var/run/sshd
+
+# access for jenkins
+RUN sed -i '/Defaults *requiretty/s/^/#/' /etc/sudoers \
+  && sed -i '/root\tALL=/a jenkins ALL=(ALL) NOPASSWD: ALL' /etc/sudoers
+RUN useradd -m -d /home/jenkins -s /bin/sh jenkins \
+  && echo "jenkins:jenkins" | chpasswd
+
+# standard SSH port
+EXPOSE 22
+
+# default command
+CMD ["/usr/sbin/sshd", "-D"]


### PR DESCRIPTION
We will need Ubuntu 16 docker image for building packages in Jenkins for Indigo 2. I created a Dockerfile based on the Ubuntu 14 version - combination of _evarga/jenkins-slave:latest_ and _indigo-dc/packaging:bubuntu_latest_.