### PR TITLE
Ubuntu 16: add locales package

### DIFF
--- a/ubuntu16/Dockerfile
+++ b/ubuntu16/Dockerfile
@@ -12,6 +12,10 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 # UTF-8 locale
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends locales \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -f /var/cache/apt/*.bin
 RUN locale-gen en_US.UTF-8
 
 # ssh, sudo, java - maven default, build tools


### PR DESCRIPTION
locales package is not installed in yhr original Ubuntu 16/xenial container anymore.

This patch fixes the docker image build.